### PR TITLE
Fix: Handle spaces in character names for global CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -3612,7 +3612,7 @@ function applyGlobalCSS(characterId) {
     }
 
     // Generate a character-specific class name for the body
-    const safeCharId = characterId.replace(/[|]/g, '-').replace(/\./g, '_');
+    const safeCharId = characterId.replace(/[|]/g, '-').replace(/\./g, '_').replace(/\s/g, '-');
     const className = `csc-global-css-${safeCharId}`;
     console.log(`[CSC] Adding global CSS class to body: ${className}`);
 


### PR DESCRIPTION
The `applyGlobalCSS` function was generating invalid CSS class names when character names contained spaces. This was because the `safeCharId` was not replacing spaces.

This commit updates the `safeCharId` generation in `applyGlobalCSS` to replace spaces with hyphens. This ensures that generated class names are always valid, preventing the `Uncaught InvalidCharacterError` when adding classes to `DOMTokenList`.